### PR TITLE
Fix exception handling for `run_in_venv`

### DIFF
--- a/.github/workflows/test-flojoy-node-env.yaml
+++ b/.github/workflows/test-flojoy-node-env.yaml
@@ -5,12 +5,12 @@ on:
     branches:
       - "main"
     paths:
-      - "flojoy/flojoy_node_env.py"
+      - "flojoy/flojoy_node_venv.py"
       - "tests/flojoy_node_venv_test_.py"
   
   pull_request:
     paths:
-      - "flojoy/flojoy_node_env.py"
+      - "flojoy/flojoy_node_venv.py"
       - "tests/flojoy_node_venv_test_.py"
     
   workflow_dispatch:

--- a/.github/workflows/test-flojoy-node-env.yaml
+++ b/.github/workflows/test-flojoy-node-env.yaml
@@ -16,8 +16,11 @@ on:
   workflow_dispatch:
 
 jobs:
-  ubuntu:
-    runs-on: ubuntu-latest
+  pytest:
+    strategy:
+      matrix:
+        os: [ubuntu, macos, windows]
+    runs-on: ${{ matrix.os }}-latest
     steps:
       - uses: actions/checkout@v3
         with:
@@ -34,50 +37,5 @@ jobs:
           pip install -e .
 
       - name: Run python tests
-        run: python -m pytest -vv tests/flojoy_node_venv_test_.py --runslow  
-    
-  macos:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: recursive
-
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-          cache: "pip"
-      - name: Install pip dependencies
         run: |
-          pip install ruff pytest
-          pip install -r requirements.txt
-          pip install -e .
-
-      - name: Run python tests
-        run: python -m pytest -vv tests/flojoy_node_venv_test_.py --runslow  
-  
-  windows:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: recursive
-
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-          cache: "pip"
-
-      - name: Install pip dependencies
-        run: |
-          pip install ruff pytest
-          pip install -r requirements.txt
-          pip install -e .
-        shell: powershell
-
-      - name: Run python tests
-        run: python -m pytest -vv tests/flojoy_node_venv_test_.py --runslow  
-        shell: powershell
-  
-
-
+          python -m pytest -vv tests/flojoy_node_venv_test_.py --runslow  

--- a/flojoy/flojoy_node_venv.py
+++ b/flojoy/flojoy_node_venv.py
@@ -195,7 +195,7 @@ def run_in_venv(pip_dependencies: list[str] | None = None, verbose: bool = False
     os.makedirs(venv_cache_dir, exist_ok=True)
     # Generate a path-safe hash of the pip dependencies
     # this prevents the duplication of virtual environments
-    pip_dependencies_hash = hashlib.md5("".join(pip_dependencies).encode()).hexdigest()[
+    pip_dependencies_hash = hashlib.md5("".join(sorted(pip_dependencies)).encode()).hexdigest()[
         :8
     ]
     venv_path = os.path.join(venv_cache_dir, f"{pip_dependencies_hash}")

--- a/flojoy/flojoy_node_venv.py
+++ b/flojoy/flojoy_node_venv.py
@@ -114,12 +114,16 @@ class PickleableFunctionWithPipeIO:
         self._func_serialized = cloudpickle.dumps(func)
         func_module_path = os.path.dirname(os.path.realpath(inspect.getabsfile(func)))
         # Check that the function is in a directory indeed
-        self._extra_sys_path = [func_module_path] if os.path.isdir(func_module_path) else None
+        self._extra_sys_path = (
+            [func_module_path] if os.path.isdir(func_module_path) else None
+        )
         self._child_conn = child_conn
         self._venv_executable = venv_executable
 
     def __call__(self, *args_serialized, **kwargs_serialized):
-        with SwapSysPath(venv_executable=self._venv_executable, extra_sys_path=self._extra_sys_path):
+        with SwapSysPath(
+            venv_executable=self._venv_executable, extra_sys_path=self._extra_sys_path
+        ):
             try:
                 fn = cloudpickle.loads(self._func_serialized)
                 args = [cloudpickle.loads(arg) for arg in args_serialized]
@@ -226,7 +230,9 @@ def run_in_venv(pip_dependencies: list[str] | None = None, verbose: bool = False
             kwargs_serialized = {
                 key: cloudpickle.dumps(value) for key, value in kwargs.items()
             }
-            pickleable_func_with_pipe = PickleableFunctionWithPipeIO(func, child_conn, venv_executable)
+            pickleable_func_with_pipe = PickleableFunctionWithPipeIO(
+                func, child_conn, venv_executable
+            )
             # Start the context manager that will change the executable used by multiprocessing
             with MultiprocessingExecutableContextManager(venv_executable):
                 # Create a new process that will run the Python code

--- a/flojoy/flojoy_node_venv.py
+++ b/flojoy/flojoy_node_venv.py
@@ -243,7 +243,9 @@ def run_in_venv(pip_dependencies: list[str] | None = None, verbose: bool = False
                 # Fetch exception and formatted traceback (list[str])
                 exception, tcb = result
                 # Reraise an exception with the same class
-                logging.error(f"[ run_in_venv ] Error in child process with the following traceback:\n{''.join(tcb)}")
+                logging.error(
+                    f"[ run_in_venv ] Error in child process with the following traceback:\n{''.join(tcb)}"
+                )
                 raise exception
             return result
 

--- a/flojoy/flojoy_node_venv.py
+++ b/flojoy/flojoy_node_venv.py
@@ -194,9 +194,9 @@ def run_in_venv(pip_dependencies: list[str] | None = None, verbose: bool = False
     os.makedirs(venv_cache_dir, exist_ok=True)
     # Generate a path-safe hash of the pip dependencies
     # this prevents the duplication of virtual environments
-    pip_dependencies_hash = hashlib.md5(
-        "".join(pip_dependencies).encode()
-    ).hexdigest()[:8]
+    pip_dependencies_hash = hashlib.md5("".join(pip_dependencies).encode()).hexdigest()[
+        :8
+    ]
     venv_path = os.path.join(venv_cache_dir, f"{pip_dependencies_hash}")
     venv_executable = _get_venv_executable_path(venv_path)
     # Create the node_env virtual environment if it does not exist

--- a/flojoy/flojoy_node_venv.py
+++ b/flojoy/flojoy_node_venv.py
@@ -198,8 +198,6 @@ def run_in_venv(pip_dependencies: list[str] | None = None, verbose: bool = False
                 logging.error(
                     f"[ _install_pip_dependencies ] Failed to install pip dependencies into virtual environment from the provided list: {pip_dependencies}. The virtual environment under {venv_path} has been deleted."
                 )
-                logging.error(
-                )
                 # Log every line of e.stderr
                 for line in e.stderr.decode().splitlines():
                     logging.error(f"[ _install_pip_dependencies ] {line}")

--- a/flojoy/flojoy_node_venv.py
+++ b/flojoy/flojoy_node_venv.py
@@ -82,6 +82,7 @@ def _install_pip_dependencies(
     venv_executable: os.PathLike, pip_dependencies: tuple[str], verbose: bool = False
 ):
     """Install pip dependencies into the virtual environment."""
+    # TODO(roulbac): Stream logs from pip install
     command = [venv_executable, "-m", "pip", "install"]
     if not verbose:
         command += ["-q", "-q"]

--- a/flojoy/flojoy_node_venv.py
+++ b/flojoy/flojoy_node_venv.py
@@ -195,9 +195,9 @@ def run_in_venv(pip_dependencies: list[str] | None = None, verbose: bool = False
     os.makedirs(venv_cache_dir, exist_ok=True)
     # Generate a path-safe hash of the pip dependencies
     # this prevents the duplication of virtual environments
-    pip_dependencies_hash = hashlib.md5("".join(sorted(pip_dependencies)).encode()).hexdigest()[
-        :8
-    ]
+    pip_dependencies_hash = hashlib.md5(
+        "".join(sorted(pip_dependencies)).encode()
+    ).hexdigest()[:8]
     venv_path = os.path.join(venv_cache_dir, f"{pip_dependencies_hash}")
     venv_executable = _get_venv_executable_path(venv_path)
     # Create the node_env virtual environment if it does not exist

--- a/flojoy/flojoy_node_venv.py
+++ b/flojoy/flojoy_node_venv.py
@@ -243,7 +243,7 @@ def run_in_venv(pip_dependencies: list[str] | None = None, verbose: bool = False
                 # Fetch exception and formatted traceback (list[str])
                 exception, tcb = result
                 # Reraise an exception with the same class
-                logging.error(f"Error in child process \n{''.join(tcb)}")
+                logging.error(f"[ run_in_venv ] Error in child process with the following traceback:\n{''.join(tcb)}")
                 raise exception
             return result
 

--- a/flojoy/flojoy_node_venv.py
+++ b/flojoy/flojoy_node_venv.py
@@ -194,9 +194,9 @@ def run_in_venv(pip_dependencies: list[str] | None = None, verbose: bool = False
     os.makedirs(venv_cache_dir, exist_ok=True)
     # Generate a path-safe hash of the pip dependencies
     # this prevents the duplication of virtual environments
-    pip_dependencies_hash = hashlib.sha256(
+    pip_dependencies_hash = hashlib.md5(
         "".join(pip_dependencies).encode()
-    ).hexdigest()
+    ).hexdigest()[:8]
     venv_path = os.path.join(venv_cache_dir, f"{pip_dependencies_hash}")
     venv_executable = _get_venv_executable_path(venv_path)
     # Create the node_env virtual environment if it does not exist

--- a/flojoy/utils.py
+++ b/flojoy/utils.py
@@ -50,9 +50,9 @@ from .dao import Dao
 from .config import FlojoyConfig, logger
 
 if sys.platform == "win32":
-    FLOJOY_CACHE_DIR = os.path.join(os.environ["APPDATA"], FLOJOY_DIR)
+    FLOJOY_CACHE_DIR = os.path.realpath(os.path.join(os.environ["APPDATA"], FLOJOY_DIR))
 else:
-    FLOJOY_CACHE_DIR = os.path.join(os.environ["HOME"], FLOJOY_DIR)
+    FLOJOY_CACHE_DIR = os.path.realpath(os.path.join(os.environ["HOME"], FLOJOY_DIR))
 
 
 # Make as a function to mock at test-time

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name="flojoy",
     packages=find_packages(exclude=["tests"]),
     package_data={"flojoy": ["__init__.pyi"]},
-    version="0.1.5-dev19",
+    version="0.1.5-dev20",
     license="MIT",
     description="Python client library for Flojoy.",
     author="flojoy",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name="flojoy",
     packages=find_packages(exclude=["tests"]),
     package_data={"flojoy": ["__init__.pyi"]},
-    version="0.1.5-dev16",
+    version="0.1.5-dev17",
     license="MIT",
     description="Python client library for Flojoy.",
     author="flojoy",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name="flojoy",
     packages=find_packages(exclude=["tests"]),
     package_data={"flojoy": ["__init__.pyi"]},
-    version="0.1.5-dev15",
+    version="0.1.5-dev16",
     license="MIT",
     description="Python client library for Flojoy.",
     author="flojoy",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name="flojoy",
     packages=find_packages(exclude=["tests"]),
     package_data={"flojoy": ["__init__.pyi"]},
-    version="0.1.5-dev17",
+    version="0.1.5-dev18",
     license="MIT",
     description="Python client library for Flojoy.",
     author="flojoy",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name="flojoy",
     packages=find_packages(exclude=["tests"]),
     package_data={"flojoy": ["__init__.pyi"]},
-    version="0.1.5-dev20",
+    version="0.1.5-dev21",
     license="MIT",
     description="Python client library for Flojoy.",
     author="flojoy",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name="flojoy",
     packages=find_packages(exclude=["tests"]),
     package_data={"flojoy": ["__init__.pyi"]},
-    version="0.1.5-dev18",
+    version="0.1.5-dev19",
     license="MIT",
     description="Python client library for Flojoy.",
     author="flojoy",

--- a/tests/flojoy_node_venv_test_.py
+++ b/tests/flojoy_node_venv_test_.py
@@ -119,5 +119,5 @@ def test_run_in_venv_does_not_hang_on_error(mock_venv_cache_dir):
         return 1 / 0
 
     # Run the function and expect an error
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ChildProcessError):
         empty_function_with_error()

--- a/tests/flojoy_node_venv_test_.py
+++ b/tests/flojoy_node_venv_test_.py
@@ -119,5 +119,5 @@ def test_run_in_venv_does_not_hang_on_error(mock_venv_cache_dir):
         return 1 / 0
 
     # Run the function and expect an error
-    with pytest.raises(ZeroDivisionError):
+    with pytest.raises(RuntimeError):
         empty_function_with_error()

--- a/tests/flojoy_node_venv_test_.py
+++ b/tests/flojoy_node_venv_test_.py
@@ -126,7 +126,8 @@ def test_run_in_venv_does_not_hang_on_error(mock_venv_cache_dir):
         empty_function_with_error()
 
 
-def test_run_in_venv_runs_within_thread(mock_venv_cache_dir):
+@pytest.mark.parametrize("daemon", [True, False])
+def test_run_in_venv_runs_within_thread(mock_venv_cache_dir, daemon):
 
     from threading import Thread
     from queue import Queue
@@ -148,7 +149,7 @@ def test_run_in_venv_runs_within_thread(mock_venv_cache_dir):
     
     # Run the function in a thread
     queue = Queue()
-    thread = Thread(target=function_to_run_within_thread, args=(queue,))
+    thread = Thread(target=function_to_run_within_thread, args=(queue,), daemon=daemon)
     thread.start()
     thread.join()
     # Check that the thread has finished

--- a/tests/flojoy_node_venv_test_.py
+++ b/tests/flojoy_node_venv_test_.py
@@ -128,25 +128,21 @@ def test_run_in_venv_does_not_hang_on_error(mock_venv_cache_dir):
 
 @pytest.mark.parametrize("daemon", [True, False])
 def test_run_in_venv_runs_within_thread(mock_venv_cache_dir, daemon):
-
     from threading import Thread
     from queue import Queue
 
     def function_to_run_within_thread(queue):
-
         from flojoy import run_in_venv
 
-        @run_in_venv(
-            pip_dependencies=["numpy==1.23.0"]
-        )
+        @run_in_venv(pip_dependencies=["numpy==1.23.0"])
         def func_with_venv():
             import numpy as np
 
             return 42
-        
+
         # Run the function
         queue.put(func_with_venv())
-    
+
     # Run the function in a thread
     queue = Queue()
     thread = Thread(target=function_to_run_within_thread, args=(queue,), daemon=daemon)
@@ -158,4 +154,3 @@ def test_run_in_venv_runs_within_thread(mock_venv_cache_dir, daemon):
     assert not queue.empty()
     # Check that the function has returned
     assert queue.get(timeout=60) == 42
-    

--- a/tests/flojoy_node_venv_test_.py
+++ b/tests/flojoy_node_venv_test_.py
@@ -11,7 +11,7 @@ pytestmark = pytest.mark.slow
 # Define a fixture to patch tempfile.tempdir
 @pytest.fixture
 def mock_venv_cache_dir():
-    _test_tempdir = os.path.join(tempfile.gettempdir(), "test_flojoy_node_venv")
+    _test_tempdir = os.path.realpath(os.path.join(tempfile.gettempdir(), "test_flojoy_node_venv"))
     # Wipe the directory to be patched if it exists
     shutil.rmtree(_test_tempdir, ignore_errors=True)
     os.makedirs(_test_tempdir)

--- a/tests/flojoy_node_venv_test_.py
+++ b/tests/flojoy_node_venv_test_.py
@@ -49,7 +49,8 @@ def test_run_in_venv_imports_jax_properly(mock_venv_cache_dir):
     # Test for executable
     assert sys_executable.startswith(mock_venv_cache_dir)
     # Test for sys.path
-    assert sys_path[-1].startswith(mock_venv_cache_dir)
+    assert sys_path[-1].startswith(os.path.dirname(__file__))
+    assert sys_path[-2].startswith(mock_venv_cache_dir)
     # Test for package version
     assert packages_dict["jax"] == "0.4.13"
 
@@ -76,7 +77,8 @@ def test_run_in_venv_imports_flytekit_properly(mock_venv_cache_dir):
     # Test for executable
     assert sys_executable.startswith(mock_venv_cache_dir)
     # Test for sys.path
-    assert sys_path[-1].startswith(mock_venv_cache_dir)
+    assert sys_path[-1].startswith(os.path.dirname(__file__))
+    assert sys_path[-2].startswith(mock_venv_cache_dir)
     # Test for package version
     assert packages_dict["flytekit"] == "1.8.2"
 
@@ -104,7 +106,8 @@ def test_run_in_venv_imports_opencv_properly(mock_venv_cache_dir):
     # Test for executable
     assert sys_executable.startswith(mock_venv_cache_dir)
     # Test for sys.path
-    assert sys_path[-1].startswith(mock_venv_cache_dir)
+    assert sys_path[-1].startswith(os.path.dirname(__file__))
+    assert sys_path[-2].startswith(mock_venv_cache_dir)
     # Test for package version
     assert packages_dict["opencv-python-headless"] == "4.7.0.72"
 

--- a/tests/flojoy_node_venv_test_.py
+++ b/tests/flojoy_node_venv_test_.py
@@ -11,7 +11,9 @@ pytestmark = pytest.mark.slow
 # Define a fixture to patch tempfile.tempdir
 @pytest.fixture
 def mock_venv_cache_dir():
-    _test_tempdir = os.path.realpath(os.path.join(tempfile.gettempdir(), "test_flojoy_node_venv"))
+    _test_tempdir = os.path.realpath(
+        os.path.join(tempfile.gettempdir(), "test_flojoy_node_venv")
+    )
     # Wipe the directory to be patched if it exists
     shutil.rmtree(_test_tempdir, ignore_errors=True)
     os.makedirs(_test_tempdir)

--- a/tests/flojoy_node_venv_test_.py
+++ b/tests/flojoy_node_venv_test_.py
@@ -124,3 +124,37 @@ def test_run_in_venv_does_not_hang_on_error(mock_venv_cache_dir):
     # Run the function and expect an error
     with pytest.raises(ChildProcessError):
         empty_function_with_error()
+
+
+def test_run_in_venv_runs_within_thread(mock_venv_cache_dir):
+
+    from threading import Thread
+    from queue import Queue
+
+    def function_to_run_within_thread(queue):
+
+        from flojoy import run_in_venv
+
+        @run_in_venv(
+            pip_dependencies=["numpy==1.23.0"]
+        )
+        def func_with_venv():
+            import numpy as np
+
+            return 42
+        
+        # Run the function
+        queue.put(func_with_venv())
+    
+    # Run the function in a thread
+    queue = Queue()
+    thread = Thread(target=function_to_run_within_thread, args=(queue,))
+    thread.start()
+    thread.join()
+    # Check that the thread has finished
+    assert not thread.is_alive()
+    # Check that there is something in the queue
+    assert not queue.empty()
+    # Check that the function has returned
+    assert queue.get(timeout=60) == 42
+    


### PR DESCRIPTION
Sometimes the function would return and attempt to pickle the resulting (broken) object before the child process is able to finish handling an exception it raised. This results in an error and the pipe blocks.
This PR fixes the issue by enclosing the whole process of deserialisation-execution-serialization into the try/catch.