### PR TITLE
Stream logs from `run_in_venv` to the `logging` module at the pip install step

### DIFF
--- a/.github/workflows/test-flojoy-node-env.yaml
+++ b/.github/workflows/test-flojoy-node-env.yaml
@@ -38,4 +38,4 @@ jobs:
 
       - name: Run python tests
         run: |
-          python -m pytest -vv tests/flojoy_node_venv_test_.py --runslow  
+          python -m pytest -vv -s tests/flojoy_node_venv_test_.py --runslow  

--- a/flojoy/flojoy_node_venv.py
+++ b/flojoy/flojoy_node_venv.py
@@ -67,8 +67,14 @@ def _install_pip_dependencies(
     with LogPipe(logging.DEBUG) as pipe_stdout, LogPipe(logging.ERROR) as pipe_stderr:
         proc = subprocess.Popen(command, stdout=pipe_stdout, stderr=pipe_stderr)
         proc.wait()
-    if(proc.returncode != 0):
-        raise subprocess.CalledProcessError(proc.returncode, command, output=pipe_stdout.buffer.getvalue(), stderr=pipe_stderr.buffer.getvalue())
+    if proc.returncode != 0:
+        raise subprocess.CalledProcessError(
+            proc.returncode,
+            command,
+            output=pipe_stdout.buffer.getvalue(),
+            stderr=pipe_stderr.buffer.getvalue(),
+        )
+
 
 def _get_venv_syspath(venv_executable: os.PathLike) -> list[str]:
     """Get the sys.path of the virtual environment."""

--- a/flojoy/flojoy_node_venv.py
+++ b/flojoy/flojoy_node_venv.py
@@ -68,7 +68,7 @@ def _install_pip_dependencies(
         proc = subprocess.Popen(command, stdout=pipe_stdout, stderr=pipe_stderr)
         proc.wait()
     if(proc.returncode != 0):
-        raise subprocess.CalledProcessError(proc.returncode, command, output=pipe_stdout.read(), stderr=pipe_stderr.read())
+        raise subprocess.CalledProcessError(proc.returncode, command, output=pipe_stdout.buffer.getvalue(), stderr=pipe_stderr.buffer.getvalue())
 
 def _get_venv_syspath(venv_executable: os.PathLike) -> list[str]:
     """Get the sys.path of the virtual environment."""

--- a/flojoy/flojoy_node_venv.py
+++ b/flojoy/flojoy_node_venv.py
@@ -64,7 +64,7 @@ def _install_pip_dependencies(
     if not verbose:
         command += ["-q", "-q"]
     command += list(pip_dependencies)
-    with LogPipe(logging.DEBUG) as pipe_stdout, LogPipe(logging.ERROR) as pipe_stderr:
+    with LogPipe(logging.INFO) as pipe_stdout, LogPipe(logging.ERROR) as pipe_stderr:
         proc = subprocess.Popen(command, stdout=pipe_stdout, stderr=pipe_stderr)
         proc.wait()
     if proc.returncode != 0:

--- a/flojoy/logging.py
+++ b/flojoy/logging.py
@@ -1,0 +1,65 @@
+import logging
+import io
+import threading
+import os
+
+class LogPipe:
+    """ A context manager that creates a pipe which can be written to by the subprocessing
+    module and read from by the logging module. This is intended to capture and redirect logs
+    from a subprocess to the logging module.
+    
+    Example usage:
+    ```
+    with logpipe.LogPipe(logging.INFO) as logpipe_stdout, logpipe.LogPipe(logging.ERROR) as logpipe_stderr:
+        with subprocess.Popen(
+            command=["python", "-m", "pip", "install", "flytekit"],
+            stdout=logpipe_stdout,
+            stderr=logpipe_stderr
+        ) as proc:
+            pass
+        # Here the logs are available in the logpipe_stdout.buffer and logpipe_stderr.buffer.
+        # This is useful for exception handling, so that we can accompany a raised exception with the logs that led to it.
+        captured_stdout = logpipe_stdout.buffer.getvalue()
+        captured_stderr = logpipe_stderr.buffer.getvalue()
+    ```
+    """
+    def __init__(self, level: int):
+        """Setup the object with a logger and a log level.
+        
+        Args:
+            level: The log level to use for the captured logs.
+        """
+        self.level = level
+        self.fdRead, self.fdWrite = os.pipe()
+        self.pipeReader = os.fdopen(self.fdRead, mode='rb')
+        self.thread = threading.Thread(target=self.run, daemon=True)
+        self.buffer = io.BytesIO()
+        self.closed = False
+
+    def __enter__(self):
+        """Start the thread when entering the context."""
+        self.thread.start()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """Ensure everything is closed and terminated when exiting the context."""
+        self.close()
+        self.thread.join(2.0)
+
+    def fileno(self):
+        """Return the write file descriptor of the pipe."""
+        return self.fdWrite
+
+    def run(self):
+        """Log everything that comes from the pipe."""
+        while not self.closed or self.pipeReader.peek():
+            byte_data = self.pipeReader.readline()
+            if byte_data:
+                logging.log(self.level, byte_data.decode("utf-8").rstrip("\n"))
+                self.buffer.write(byte_data)
+        self.pipeReader.close()
+
+    def close(self):
+        """Close the write end of the pipe."""
+        os.close(self.fdWrite)
+        self.closed = True

--- a/flojoy/logging.py
+++ b/flojoy/logging.py
@@ -3,11 +3,12 @@ import io
 import threading
 import os
 
+
 class LogPipe:
-    """ A context manager that creates a pipe which can be written to by the subprocessing
+    """A context manager that creates a pipe which can be written to by the subprocessing
     module and read from by the logging module. This is intended to capture and redirect logs
     from a subprocess to the logging module.
-    
+
     Example usage:
     ```
     with logpipe.LogPipe(logging.INFO) as logpipe_stdout, logpipe.LogPipe(logging.ERROR) as logpipe_stderr:
@@ -23,15 +24,16 @@ class LogPipe:
         captured_stderr = logpipe_stderr.buffer.getvalue()
     ```
     """
+
     def __init__(self, level: int):
         """Setup the object with a logger and a log level.
-        
+
         Args:
             level: The log level to use for the captured logs.
         """
         self.level = level
         self.fdRead, self.fdWrite = os.pipe()
-        self.pipeReader = os.fdopen(self.fdRead, mode='rb')
+        self.pipeReader = os.fdopen(self.fdRead, mode="rb")
         self.thread = threading.Thread(target=self.run, daemon=True)
         self.buffer = io.BytesIO()
         self.closed = False

--- a/flojoy/logging.py
+++ b/flojoy/logging.py
@@ -2,6 +2,7 @@ import logging
 import io
 import threading
 import os
+from time import sleep 
 
 
 class LogPipe:
@@ -59,6 +60,8 @@ class LogPipe:
             if byte_data:
                 logging.log(self.level, byte_data.decode("utf-8").rstrip("\n"))
                 self.buffer.write(byte_data)
+            else:
+                sleep(0.1)
         self.pipeReader.close()
 
     def close(self):

--- a/tests/flojoy_node_venv_test_.py
+++ b/tests/flojoy_node_venv_test_.py
@@ -8,12 +8,13 @@ import logging
 
 pytestmark = pytest.mark.slow
 
+
 @pytest.fixture(scope="module")
 def logging_debug():
     logging.basicConfig(
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
         level=logging.DEBUG,
-        force=True
+        force=True,
     )
 
 

--- a/tests/flojoy_node_venv_test_.py
+++ b/tests/flojoy_node_venv_test_.py
@@ -3,9 +3,18 @@ import os
 import shutil
 from unittest.mock import patch
 import tempfile
+import logging
 
 
 pytestmark = pytest.mark.slow
+
+@pytest.fixture(scope="module")
+def logging_debug():
+    logging.basicConfig(
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        level=logging.DEBUG,
+        force=True
+    )
 
 
 # Define a fixture to patch tempfile.tempdir
@@ -26,12 +35,12 @@ def mock_venv_cache_dir():
     shutil.rmtree(_test_tempdir)
 
 
-def test_run_in_venv_imports_jax_properly(mock_venv_cache_dir):
+def test_run_in_venv_imports_jax_properly(mock_venv_cache_dir, logging_debug):
     """Test that run_in_venv imports properly jax for example"""
 
     from flojoy import run_in_venv
 
-    @run_in_venv(pip_dependencies=["jax[cpu]==0.4.13"])
+    @run_in_venv(pip_dependencies=["jax[cpu]==0.4.13"], verbose=True)
     def empty_function_with_jax():
         # Import jax to check if it is installed
         # Fetch the list of installed packages
@@ -56,11 +65,11 @@ def test_run_in_venv_imports_jax_properly(mock_venv_cache_dir):
     assert packages_dict["jax"] == "0.4.13"
 
 
-def test_run_in_venv_imports_flytekit_properly(mock_venv_cache_dir):
+def test_run_in_venv_imports_flytekit_properly(mock_venv_cache_dir, logging_debug):
     from flojoy import run_in_venv
 
     # Define a function that imports flytekit and returns its version
-    @run_in_venv(pip_dependencies=["flytekit==1.8.2"])
+    @run_in_venv(pip_dependencies=["flytekit==1.8.2"], verbose=True)
     def empty_function_with_flytekit():
         import sys
         import importlib.metadata
@@ -83,12 +92,12 @@ def test_run_in_venv_imports_flytekit_properly(mock_venv_cache_dir):
     assert packages_dict["flytekit"] == "1.8.2"
 
 
-def test_run_in_venv_imports_opencv_properly(mock_venv_cache_dir):
+def test_run_in_venv_imports_opencv_properly(mock_venv_cache_dir, logging_debug):
     # Define a function that imports opencv-python-headless and returns its version
 
-    from flojoy import flojoy, run_in_venv
+    from flojoy import run_in_venv
 
-    @run_in_venv(pip_dependencies=["opencv-python-headless==4.7.0.72"])
+    @run_in_venv(pip_dependencies=["opencv-python-headless==4.7.0.72"], verbose=True)
     def empty_function_with_opencv():
         import sys
         import importlib.metadata
@@ -111,7 +120,7 @@ def test_run_in_venv_imports_opencv_properly(mock_venv_cache_dir):
     assert packages_dict["opencv-python-headless"] == "4.7.0.72"
 
 
-def test_run_in_venv_does_not_hang_on_error(mock_venv_cache_dir):
+def test_run_in_venv_does_not_hang_on_error(mock_venv_cache_dir, logging_debug):
     """Test that run_in_venv imports properly jax for example"""
 
     from flojoy import run_in_venv
@@ -126,14 +135,14 @@ def test_run_in_venv_does_not_hang_on_error(mock_venv_cache_dir):
 
 
 @pytest.mark.parametrize("daemon", [True, False])
-def test_run_in_venv_runs_within_thread(mock_venv_cache_dir, daemon):
+def test_run_in_venv_runs_within_thread(mock_venv_cache_dir, logging_debug, daemon):
     from threading import Thread
     from queue import Queue
 
     def function_to_run_within_thread(queue):
         from flojoy import run_in_venv
 
-        @run_in_venv(pip_dependencies=["numpy==1.23.0"])
+        @run_in_venv(pip_dependencies=["numpy==1.23.0"], verbose=True)
         def func_with_venv():
             import numpy as np
 


### PR DESCRIPTION
We introduce `LogPipe` which allows logging from the created subprocess by `_install_pip_dependencies` into the main parent process.

Sometime a pip install step can take a while, and it is important to stream logs back in real time so that the user can know what's happening. 

`LogPipe` was tested on both Mac and Windows. Additionally, the `test-flojoy-node-env` github action was made verbose to check that the logs are streamed there as well for Mac/Windows/Ubuntu.

cc @jackparmer @itsjoeoui 