### PR TITLE
ci: Update to actions@v4

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -24,7 +24,7 @@
 #     runs-on: ubuntu-latest
 #
 #     steps:
-#       - uses: actions/checkout@v3
+#       - uses: actions/checkout@v4
 #       - name: Set up Python
 #         uses: actions/setup-python@v3
 #         with:

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/test-flojoy-node-env.yaml
+++ b/.github/workflows/test-flojoy-node-env.yaml
@@ -22,7 +22,7 @@ jobs:
         os: [ubuntu, macos, windows]
     runs-on: ${{ matrix.os }}-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 


### PR DESCRIPTION
`action@v3` is currently faulty, see https://github.com/actions/checkout/issues/1448.

Errors are observed on https://github.com/flojoy-ai/python/pull/96, see [this log](https://github.com/flojoy-ai/python/actions/runs/6081630247/job/16497662316?pr=96#step:1:36).