### PR TITLE
Add NI to connection manager

### DIFF
--- a/flojoy/connection_manager.py
+++ b/flojoy/connection_manager.py
@@ -9,6 +9,8 @@ from flojoy.parameter_types import (
     SerialConnection,
     VisaDevice,
     VisaConnection,
+    NIDevice,
+    NIConnection,
 )
 from typing import Any
 from .config import logger
@@ -33,6 +35,8 @@ class DeviceConnectionManager:
                     cls.handles[id] = SerialConnection(connection)
                 case VisaDevice():
                     cls.handles[id] = VisaConnection(connection)
+                case NIDevice():
+                    cls.handles[id] = NIConnection(connection)
 
     @classmethod
     def get_connection(cls, id: str | int) -> HardwareConnection:

--- a/flojoy/parameter_types.py
+++ b/flojoy/parameter_types.py
@@ -38,6 +38,10 @@ class SerialDevice(HardwareDevice):
 class VisaDevice(HardwareDevice):
     def get_address(self):
         return str(self.get_id())
+    
+
+class NIDevice(HardwareDevice):
+    pass
 
 
 class CameraConnection(HardwareConnection):
@@ -48,8 +52,14 @@ class CameraConnection(HardwareConnection):
 class SerialConnection(HardwareConnection):
     def __del__(self):
         self._handle.close()
-    
+
+
 class VisaConnection(HardwareConnection):
+    def __del__(self):
+        self._handle.close()
+
+
+class NIConnection(HardwareConnection):
     def __del__(self):
         self._handle.close()
 


### PR DESCRIPTION
Add `NIdevice` and `NIconnection` for national instrument connections. Unfortunately there's no way of adding them to the hardware tab. 