### PR TITLE
Use fstring instead of multiple arg for logging and some refactoring

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "[python]": {
+    "editor.defaultFormatter": "ms-python.black-formatter"
+  },
+  "python.formatting.provider": "none"
+}

--- a/flojoy/CONSTANTS.py
+++ b/flojoy/CONSTANTS.py
@@ -1,2 +1,10 @@
+import sys, os
+
 KEY_WORKER_JOBS = "WORKER_JOBS"
 KEY_ALL_JOBEST_IDS = "ALL_JOBSET_IDS"
+FLOJOY_DIR = ".flojoy"
+CREDENTIAL_FILE= "credentials.txt"
+if sys.platform == "win32":
+    FLOJOY_CACHE_DIR = os.path.realpath(os.path.join(os.environ["APPDATA"], FLOJOY_DIR))
+else:
+    FLOJOY_CACHE_DIR = os.path.realpath(os.path.join(os.environ["HOME"], FLOJOY_DIR))

--- a/flojoy/flojoy_node_venv.py
+++ b/flojoy/flojoy_node_venv.py
@@ -20,10 +20,9 @@ def TORCH_NODE(default: Matrix) -> Matrix:
 
 """
 from collections.abc import Callable, Iterable, Mapping
-from concurrent.futures import Future, ThreadPoolExecutor
 import threading
 from time import sleep
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 import hashlib
 from contextlib import ExitStack, contextmanager
@@ -42,7 +41,7 @@ import venv
 from functools import wraps
 import cloudpickle
 
-from .utils import FLOJOY_CACHE_DIR
+from .CONSTANTS import FLOJOY_CACHE_DIR
 from .logging import LogPipe, LogPipeMode, StreamEnum
 
 __all__ = ["run_in_venv"]
@@ -100,7 +99,7 @@ def _bootstrap_venv(
     # Acquire a lock on the virtual environment to ensure no other process is using it
     with portalocker.Lock(
         lockfile_path, mode="ab", fail_when_locked=False, flags=portalocker.LOCK_EX
-    ) as lock:
+    ):
         logger.info(f"Acquired lock on {lockfile_path}...")
         # Check if the virtual environment is complete, i.e. it contains a .venv_is_complete file
         venv_is_complete_path = os.path.realpath(
@@ -183,8 +182,6 @@ def _bootstrap_venv(
         with open(venv_is_complete_path, "w") as f:
             f.write("")
 
-    # Leaved the portalocker.Lock on the virtual environment directory.
-    return
 
 
 class PipInstallThread(threading.Thread):

--- a/flojoy/flojoy_python.py
+++ b/flojoy/flojoy_python.py
@@ -1,5 +1,4 @@
 from contextlib import ContextDecorator
-import json
 import os
 import traceback
 from functools import wraps
@@ -10,15 +9,13 @@ from .models.JobResults.JobSuccess import JobSuccess
 
 from .node_init import NodeInitService
 from .data_container import DataContainer, Stateful
-from .utils import PlotlyJSONEncoder
 from typing import Callable, Any, Optional
 from .job_result_utils import get_frontend_res_obj_from_result, get_dc_from_result
-from .utils import send_to_socket, get_hf_hub_cache_path
+from .utils import get_hf_hub_cache_path
 from .config import logger
 from .parameter_types import format_param_value
 from inspect import signature
 from .job_service import JobService
-from timeit import default_timer as timer
 from .connection_manager import DeviceConnectionManager
 
 __all__ = ["flojoy", "DefaultParams", "display"]
@@ -48,12 +45,8 @@ def fetch_inputs(previous_jobs: list[dict[str, str]]):
             edge = prev_job.get("edge", "")
 
             logger.debug(
-                "fetching input from prev job id:",
-                prev_job_id,
-                " for input:",
-                input_name,
-                "edge: ",
-                edge,
+                f"fetching input from prev job id: {prev_job_id}"
+                + f"for input: {input_name} edge: {edge}"
             )
 
             job_result = JobService().get_job_result(prev_job_id)
@@ -77,8 +70,8 @@ def fetch_inputs(previous_jobs: list[dict[str, str]]):
                 else:
                     dict_inputs[input_name] = result
 
-    except Exception:
-        logger.debug(traceback.format_exc())
+    except Exception as e:
+        logger.debug(f"{e} {traceback.format_exc()}")
 
     return dict_inputs
 
@@ -180,7 +173,7 @@ def flojoy(
             ctrls: dict[str, Any] | None = None,
         ):
             try:
-                logger.debug("previous jobs:", previous_jobs)
+                logger.debug(f"previous jobs: {previous_jobs}")
                 # Get command parameters set by the user through the control panel
                 func_params: dict[str, Any] = {}
                 if ctrls is not None:
@@ -191,10 +184,7 @@ def flojoy(
                 func_params["type"] = "default"
 
                 logger.debug(
-                    "executing node_id:",
-                    node_id,
-                    "previous_jobs:",
-                    previous_jobs,
+                    f"executing node_id: {node_id} previous_jobs: {previous_jobs}"
                 )
                 dict_inputs = fetch_inputs(previous_jobs)
 
@@ -216,18 +206,18 @@ def flojoy(
                         node_type="default",
                     )
 
-                logger.debug(node_id, " params: ", args.keys())
+                logger.debug(f"{node_id} params: {args.keys()}")
 
                 # check if node has an init container and if so, inject it
                 if NodeInitService().has_init_store(node_id):
                     args["init_container"] = NodeInitService().get_init_store(node_id)
 
                 if inject_connection:
-                    print("injecting connection", flush=True)
+                    logger.debug("injecting connection")
                     device = args["connection"]
-                    print(f"device handle: {device}", flush=True)
-                    id = device.get_id()
-                    connection = DeviceConnectionManager.get_connection(id)
+                    logger.debug(f"device handle: {device}")
+                    _id = device.get_id()
+                    connection = DeviceConnectionManager.get_connection(_id)
                     args["connection"] = connection
 
                 ##########################


### PR DESCRIPTION
The logging module expects a single parameter for all of its methods debug, error, and info. Thus converted all multi-params to fstring to fix the following error:
```txt
[2023-10-03 19:18:12] - flojoy - ERROR - not all arguments converted during string formatting
[2023-10-03 19:18:12] - flojoy - ERROR - error occured while running the node
[2023-10-03 19:18:12] - flojoy - DEBUG - Traceback (most recent call last):
  File "H:\flojoy\studio\venv\lib\site-packages\flojoy\flojoy_python.py", line 183, in wrapper
    logger.debug("previous jobs:", previous_jobs)
  File "F:\programs\Python\lib\logging\__init__.py", line 1465, in debug
    self._log(DEBUG, msg, args, **kwargs)
  File "F:\programs\Python\lib\logging\__init__.py", line 1624, in _log
    self.handle(record)
  File "F:\programs\Python\lib\logging\__init__.py", line 1634, in handle
    self.callHandlers(record)
  File "F:\programs\Python\lib\logging\__init__.py", line 1696, in callHandlers
    hdlr.handle(record)
  File "F:\programs\Python\lib\logging\__init__.py", line 968, in handle
    self.emit(record)
  File "H:\flojoy\studio\captain\utils\logger.py", line 51, in emit
    log_entry = self.format(record)
  File "F:\programs\Python\lib\logging\__init__.py", line 943, in format
    return fmt.format(record)
  File "F:\programs\Python\lib\logging\__init__.py", line 678, in format
    record.message = record.getMessage()
  File "F:\programs\Python\lib\logging\__init__.py", line 368, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting
```